### PR TITLE
Respect Alchemy.admin_path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Alchemy::Engine.routes.draw do
-  namespace :admin do
+  namespace :admin, {path: Alchemy.admin_path, constraints: Alchemy.admin_constraints} do
     get 'usermanual', :to => 'user_manual#show', :as => 'usermanual'
   end
 end

--- a/spec/controllers/admin/user_manual_controller_spec.rb
+++ b/spec/controllers/admin/user_manual_controller_spec.rb
@@ -15,6 +15,22 @@ module Alchemy
           controller.send :show
           expect(assigns :manual).to be_instance_of(UserManual::Creator)
         end
+
+        context 'with Alchemy.admin_path customised' do
+          before(:all) do
+            Alchemy.admin_path = '/backend'
+            Rails.application.reload_routes!
+          end
+
+          it 'uses the custom admin path' do
+            expect(admin_usermanual_path).to eq('/backend/usermanual')
+          end
+
+          after(:all) do
+            Alchemy.admin_path = '/admin'
+            Rails.application.reload_routes!
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,5 @@ Rails.logger.level = 4
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.include FactoryGirl::Syntax::Methods
+  config.include Alchemy::Engine.routes.url_helpers
 end


### PR DESCRIPTION
Alchemy 3.3 has the ability to change the path the admin is located at. This PR makes alchemy-usermanual respect that path.
